### PR TITLE
Fix import in Messier service test

### DIFF
--- a/tests/messierService.test.ts
+++ b/tests/messierService.test.ts
@@ -1,4 +1,5 @@
-import {test, strictEqual} from 'node:test';
+import { test } from 'node:test';
+import { strictEqual } from 'node:assert/strict';
 import messierService, { MESSIER_URL } from '../src/services/messierService.ts';
 import axios from 'axios';
 


### PR DESCRIPTION
## Summary
- rename test to TypeScript file
- import `strictEqual` from `node:assert/strict`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687848db294c8331973d7db307830eef